### PR TITLE
Bumping multiple dependencies

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,22 +5,22 @@ object Sdk {
 }
 
 object Versions {
-    const val ANDROIDX_TEST_EXT = "1.1.1"
-    const val ANDROIDX_TEST = "1.2.0"
-    const val APPCOMPAT = "1.1.0"
-    const val CONSTRAINT_LAYOUT = "1.1.3"
+    const val ANDROIDX_TEST_EXT = "1.1.2"
+    const val ANDROIDX_TEST = "1.3.0"
+    const val APPCOMPAT = "1.2.0"
+    const val CONSTRAINT_LAYOUT = "2.0.2"
     const val CORE_KTX = "1.2.0"
-    const val ESPRESSO_CORE = "3.2.0"
-    const val JUNIT = "4.13"
+    const val ESPRESSO_CORE = "3.3.0"
+    const val JUNIT = "4.13.1"
     const val KTLINT = "0.39.0"
 }
 
 object BuildPluginsVersion {
-    const val AGP = "4.0.0"
+    const val AGP = "4.1.0"
     const val DETEKT = "1.14.2"
     const val KOTLIN = "1.3.72"
     const val KTLINT = "9.4.1"
-    const val VERSIONS_PLUGIN = "0.28.0"
+    const val VERSIONS_PLUGIN = "0.33.0"
 }
 
 object SupportLibs {


### PR DESCRIPTION
- ANDROIDX_TEST_EXT to 1.1.2
- ANDROIDX_TEST to 1.3.0
- APPCOMPAT to 1.2.0
- CONSTRAINT_LAYOUT to 2.0.2
- ESPRESSO_CORE to 3.3.0
- JUNIT to 4.13.1

Gradle Plugins

- AGP to 4.1.0
- VERSIONS_PLUGIN to 0.33.0