### PR TITLE
AGP to 4.1.1 + Remove kotlin-android-extension

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    id("kotlin-android-extensions")
 }
 
 android {
@@ -16,10 +15,12 @@ android {
         versionName = AppCoordinates.APP_VERSION_NAME
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
@@ -28,6 +29,10 @@ android {
                 "proguard-rules.pro"
             )
         }
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 
     lintOptions {

--- a/app/src/main/java/com/ncorti/kotlin/template/app/MainActivity.kt
+++ b/app/src/main/java/com/ncorti/kotlin/template/app/MainActivity.kt
@@ -3,9 +3,9 @@ package com.ncorti.kotlin.template.app
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.ncorti.kotlin.template.app.databinding.ActivityMainBinding
 import com.ncorti.kotlin.template.library.FactorialCalculator
 import com.ncorti.kotlin.template.library.android.NotificationUtil
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
@@ -13,14 +13,16 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
 
-        button_compute.setOnClickListener {
-            val input = edit_text_factorial.text.toString().toInt()
+        val binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.buttonCompute.setOnClickListener {
+            val input = binding.editTextFactorial.text.toString().toInt()
             val result = FactorialCalculator.computeFactorial(input).toString()
 
-            text_result.text = result
-            text_result.visibility = View.VISIBLE
+            binding.textResult.text = result
+            binding.textResult.visibility = View.VISIBLE
 
             notificationUtil.showNotification(
                 context = this,

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,7 +16,7 @@ object Versions {
 }
 
 object BuildPluginsVersion {
-    const val AGP = "4.1.0"
+    const val AGP = "4.1.1"
     const val DETEKT = "1.14.2"
     const val KOTLIN = "1.3.72"
     const val KTLINT = "9.4.1"

--- a/library-android/build.gradle.kts
+++ b/library-android/build.gradle.kts
@@ -3,7 +3,6 @@ version = LibraryAndroidCoordinates.LIBRARY_VERSION
 plugins {
     id("com.android.library")
     kotlin("android")
-    id("kotlin-android-extensions")
     id("maven-publish")
 }
 


### PR DESCRIPTION
## 🚀 Description
I published this PR to update to the latest dependency for AGP and Kotlin Android Extension specifically.

## 📄 Motivation and Context
I completed coding until I saw #24. However, I still think there is a sense of urgency.
1. Android Studio 4.1.0 has significant UI freeze regression. This is regarded as a bad version in my company. https://issuetracker.google.com/issues/165821809
2. Kotlin android extension has been announced to be [deprecated](https://android-developers.googleblog.com/2020/11/the-future-of-kotlin-android-extensions.html), we should be able to spread the word 👍 

## 🧪 How Has This Been Tested?
`./gradlew run`
`./gradlew check`
`./gradlew connectedAndroid`

## 📷 Screenshots (if appropriate)
![device-2020-12-25-223220](https://user-images.githubusercontent.com/1175468/103146614-18b53400-4701-11eb-98c9-7eab91a40c84.png)

## 📦 Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.