### PR TITLE
Setup to publishing to Maven Central

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,38 @@
+name: Publish Release
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    if: ${{ github.repository == 'cortinico/kotlin-android-template'}}
+    runs-on: [ubuntu-latest]
+    env:
+      GRADLE_OPTS: -Dorg.gradle.parallel=false
+
+    steps:
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Publish to Maven Local
+        run: ./gradlew publishToMavenLocal
+        env:
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'release-artifacts'
+          path: '~/.m2/repository/'
+
+      - name: Publish to the Snapshot Repository
+        run: ./gradlew publishReleasePublicationToNexusRepository
+        env:
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+          ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -1,0 +1,40 @@
+name: Publish Snapshot
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  publish:
+    if: ${{ github.repository == 'cortinico/kotlin-android-template'}}
+    runs-on: [ubuntu-latest]
+    env:
+      GRADLE_OPTS: -Dorg.gradle.parallel=false
+
+    steps:
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Publish to Maven Local
+        run: ./gradlew publishToMavenLocal
+        env:
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+          ORG_GRADLE_PROJECT_USE_SNAPSHOT: true
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'snapshot-artifacts'
+          path: '~/.m2/repository/'
+
+      - name: Publish to the Snapshot Repository
+        run: ./gradlew publishReleasePublicationToSnapshotRepository
+        env:
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+          ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_USE_SNAPSHOT: true

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Once created don't forget to update the:
 - 3 Sample modules (Android app, Android library, Kotlin library).
 - Sample Espresso, Instrumentation & JUnit tests.
 - 100% Gradle Kotlin DSL setup.
-- Dependency versions managed via `buildSrc`.
 - CI Setup with GitHub Actions.
+- Publish to **Maven Central** with Github Actions.
+- Dependency versions managed via `buildSrc`.
 - Kotlin Static Analysis via `ktlint` and `detekt`.
-- Publishing Ready.
 - Issues Template (bug report + feature request).
 - Pull Request Template.
 
@@ -46,11 +46,45 @@ This template is using [**GitHub Actions**](https://github.com/cortinico/kotlin-
 
 There are currently the following workflows available:
 - [Validate Gradle Wrapper](.github/workflows/gradle-wrapper-validation.yml) - Will check that the gradle wrapper has a valid checksum
-- [Pre Merge Checks](.github/workflows/pre-merge.yaml) - Will run the `build`, `check` and `publishToMavenLocal` tasks. 
+- [Pre Merge Checks](.github/workflows/pre-merge.yaml) - Will run the `build`, `check` and `publishToMavenLocal` tasks.
+- [Publish Snapshot](.github/workflows/publish-snapshot.yaml) - Will publish a `-SNAPSHOT` of the libraries to Sonatype.
+- [Publish Release](.github/workflows/publish-release.yaml) - Will publish a new release version of the libraries to Maven Central on tag pushes.
 
 ## Publishing 🚀
 
-The template is setup to be **ready to publish** a library/artifact on a Maven Repository. If you're using JitPack, you don't need any further configuration and you can just configure the repo on JitPack. If you're using another repository (MavenCentral/JCenter/etc.), you need to specify the publishing coordinates.
+The template is setup to be **ready to publish** a library/artifact on a Maven Repository.
+
+For every module you want to publish you simply have to add the `publish` plugin:
+
+```
+plugins {
+    publish
+}
+```
+
+### To Maven Central
+
+In order to use this template to publish on Maven Central, you need to configure some secrets on your repository:
+
+| Secret name | Value |
+| --- | --- | 
+| `ORG_GRADLE_PROJECT_NEXUS_USERNAME` | The username you use to access Sonatype's services (such as [Nexus](https://oss.sonatype.org/) and [Jira](https://issues.sonatype.org/)) |
+| `ORG_GRADLE_PROJECT_NEXUS_PASSWORD` | The password you use to access Sonatype's services (such as [Nexus](https://oss.sonatype.org/) and [Jira](https://issues.sonatype.org/)) |
+| `ORG_GRADLE_PROJECT_SIGNING_KEY` | The GPG Private key to sign your artifacts. You can obtain it with `gpg --armor --export-secret-keys <your@email.here>` or you can create one key online on [pgpkeygen.com](https://pgpkeygen.com). The key starts with a `-----BEGIN PGP PRIVATE KEY BLOCK-----`. |
+| `ORG_GRADLE_PROJECT_SIGNING_PWD` | The passphrase to unlock your private key (you picked it when creating the key). |
+
+The template already sets up [Dokka](https://kotlin.github.io/dokka/) for project documentation and attaches `-sources.jar` to your publications.
+
+Once set up, the following workflows will take care of publishing:
+
+- [Publish Snapshot](.github/workflows/publish-snapshot.yaml) - To publish `-SNAPSHOT` versions to Sonatype. The workflow is setup to run either manually (with `workflow_dispatch`) or on every merge.
+- [Publish Release](.github/workflows/publish-release.yaml) - Will publish a new release version of the libraries to Maven Central on tag pushes. You can trigger the workflow also manually if needed.
+
+### To Jitpack
+
+If you're using [JitPack](https://jitpack.io/), you don't need any further configuration and you can just configure the repo on JitPack.
+
+You probably want to disable the [Publish Snapshot] and [Publish Release](.github/workflows/publish-release.yaml) workflows (delete the files), as Jitpack will take care of that for you.
 
 ## Contributing 🤝
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {
-    id("com.android.application") version BuildPluginsVersion.AGP apply false
-    id("com.android.library") version BuildPluginsVersion.AGP apply false
-    kotlin("android") version BuildPluginsVersion.KOTLIN apply false
+    id("com.android.application") apply false
+    id("com.android.library") apply false
+    kotlin("android") apply false
     id("io.gitlab.arturbosch.detekt") version BuildPluginsVersion.DETEKT
     id("org.jlleitschuh.gradle.ktlint") version BuildPluginsVersion.KTLINT
     id("com.github.ben-manes.versions") version BuildPluginsVersion.VERSIONS_PLUGIN

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,4 +3,20 @@ plugins {
 }
 repositories {
     jcenter()
+    google()
+}
+
+kotlinDslPluginOptions.experimentalWarning.set(false)
+
+object Plugins {
+    const val AGP = "4.1.2"
+    const val DOKKA = "1.4.20"
+    const val KOTLIN = "1.4.30"
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${Plugins.KOTLIN}")
+    implementation("com.android.tools.build:gradle:${Plugins.AGP}")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:${Plugins.DOKKA}")
+    implementation("org.jetbrains.dokka:dokka-core:${Plugins.DOKKA}")
 }

--- a/buildSrc/src/main/java/Coordinates.kt
+++ b/buildSrc/src/main/java/Coordinates.kt
@@ -8,10 +8,10 @@ object AppCoordinates {
 }
 
 object LibraryAndroidCoordinates {
-    const val LIBRARY_VERSION = "1.0"
+    const val LIBRARY_VERSION = "1.0.0"
     const val LIBRARY_VERSION_CODE = 1
 }
 
 object LibraryKotlinCoordinates {
-    const val LIBRARY_VERSION = "1.0"
+    const val LIBRARY_VERSION = "1.0.0"
 }

--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -1,0 +1,138 @@
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.tasks.bundling.Jar
+
+/**
+ * Precompiled script plugin from:
+ * https://github.com/cortinico/kotlin-android-template/blob/master/buildSrc/src/main/kotlin/publish.gradle.kts
+ *
+ * The following plugin tasks care of setting up:
+ * - Publishing to Maven Central and Sonatype Snapshots
+ * - GPG Signing with in memory PGP Keys
+ * - Dokka for documentation
+ * - sourceJar for attaching sources to publications
+ *
+ * To use it just apply:
+ *
+ * plugins {
+ *     publish
+ * }
+ *
+ * To your build.gradle.kts.
+ *
+ * If you copy over this file in your project, make sure to copy it inside: buildSrc/src/main/kotlin/publish.gradle.kts.
+ * Make sure to copy over also buildSrc/build.gradle.kts otherwise this plugin will fail to compile due to missing dependencies.
+ */
+plugins {
+    id("maven-publish")
+    id("signing")
+    id("org.jetbrains.dokka")
+}
+
+val dokkaJar = tasks.create<Jar>("dokkaJar") {
+    group = "build"
+    description = "Assembles Javadoc jar from Dokka API docs"
+    archiveClassifier.set("javadoc")
+    from(tasks.dokkaJavadoc)
+}
+
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    group = "build"
+    description = "Assembles Source jar for publishing"
+    archiveClassifier.set("sources")
+    if (plugins.hasPlugin("com.android.library")) {
+        from((project.extensions.getByName("android") as LibraryExtension).sourceSets.named("main").get().java.srcDirs)
+    } else {
+        from((project.extensions.getByName("sourceSets") as SourceSetContainer).named("main").get().allSource)
+    }
+}
+
+tasks.dokkaJavadoc.configure {
+    outputDirectory.set(buildDir.resolve("javadoc"))
+    dokkaSourceSets {
+        configureEach {
+            sourceRoot(file("src"))
+        }
+    }
+}
+
+
+afterEvaluate {
+
+    publishing {
+        repositories {
+            maven {
+                name = "nexus"
+                url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                credentials {
+                    username = "NEXUS_USERNAME".byProperty
+                    password = "NEXUS_PASSWORD".byProperty
+                }
+            }
+            maven {
+                name = "snapshot"
+                url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                credentials {
+                    username = "NEXUS_USERNAME".byProperty
+                    password = "NEXUS_PASSWORD".byProperty
+                }
+            }
+        }
+
+        publications {
+            create<MavenPublication>("release") {
+                if (plugins.hasPlugin("com.android.library")) {
+                    from(components["release"])
+                } else {
+                    from(components["java"])
+                }
+                artifact(dokkaJar)
+                artifact(sourcesJar)
+
+                pom {
+                    if (!"USE_SNAPSHOT".byProperty.isNullOrBlank()) {
+                        version = "$version-SNAPSHOT"
+                    }
+                    description.set("A template for Kotlin Android projects")
+                    url.set("https://github.com/cortinico/kotlin-android-template/")
+
+                    licenses {
+                        license {
+                            name.set("The MIT License")
+                            url.set("https://opensource.org/licenses/MIT")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("cortinico")
+                            name.set("Nicola Corti")
+                            email.set("corti.nico@gmail.com")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:git://github.com/cortinico/kotlin-android-template.git")
+                        developerConnection.set("scm:git:ssh://github.com/cortinico/kotlin-android-template.git")
+                        url.set("https://github.com/cortinico/kotlin-android-template/")
+                    }
+                    issueManagement {
+                        system.set("GitHub Issues")
+                        url.set("https://github.com/cortinico/kotlin-android-template/issues")
+                    }
+                }
+            }
+        }
+
+        val signingKey = "SIGNING_KEY".byProperty
+        val signingPwd = "SIGNING_PWD".byProperty
+        if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
+            logger.info("Signing Disable as the PGP key was not found")
+        } else {
+            logger.warn("Usign $signingKey - $signingPwd")
+            signing {
+                useInMemoryPgpKeys(signingKey, signingPwd)
+                sign(publishing.publications["release"])
+            }
+        }
+    }
+}
+
+val String.byProperty: String? get() = findProperty(this) as? String

--- a/library-android/build.gradle.kts
+++ b/library-android/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     kotlin("android")
     id("maven-publish")
+    publish
 }
 
 android {
@@ -51,14 +52,4 @@ dependencies {
 
     androidTestImplementation(AndroidTestingLib.ANDROIDX_TEST_RUNNER)
     androidTestImplementation(AndroidTestingLib.ANDROIDX_TEST_EXT_JUNIT)
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-            }
-        }
-    }
 }

--- a/library-kotlin/build.gradle.kts
+++ b/library-kotlin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("java-library")
     kotlin("jvm")
     id("maven-publish")
+    publish
 }
 
 dependencies {
@@ -15,12 +16,4 @@ dependencies {
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
-    }
 }


### PR DESCRIPTION
## 🚀 Description
Update the template to supports easy publishing to Maven Central via Github Actions.

## 📄 Motivation and Context

With the sunset of `jcenter()`, libraries need to move to Maven Central (or other alternatives). I'm updating the template to support creation of new projects that are already _Central-ready_ (plus I'll use this as a personal reference 😅).

The approach here uses **only first party plugin**, and delegates the publishing to Github Actions:
- `maven-publish` to publish to both Maven Central and Sonatype Snapshots (for `-SNAPSHOT` versions).
- `signing` for GPG Signing with in memory PGP Keys
- `dokka` for documentation

All is bundled as a precompiled script plugin: `publish.gradle.kts` that is easy to copy and move around if needed. To use it just apply:

```
plugins {
    publish
}
```

to the `build.gradle.kts` of the module you want to publish.

If you copy over the `publish.gradle.kts` file, make sure to copy it inside: `buildSrc/src/main/kotlin/publish.gradle.kts`.

Make sure to copy over also `buildSrc/build.gradle.kts` (or integrate the changes) otherwise this plugin will fail to compile due to missing `dependencies`.
