### PR TITLE
Add a template-cleanup action

### DIFF
--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -1,0 +1,10 @@
+# %NAME%
+
+![Build](https://github.com/%REPOSITORY%/workflows/Build/badge.svg)
+
+## Template ToDo list
+- [x] Create a new [Kotlin Android Template][template] project.
+- [ ] Choose a [license](https://github.com/%REPOSITORY%/community/license/new?branch=master).
+- [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in Github Actions.
+
+This is your new Kotlin Android Project! Happy hacking!

--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -6,5 +6,6 @@
 - [x] Create a new template project.
 - [ ] Choose a [LICENSE](https://github.com/%REPOSITORY%/community/license/new?branch=master).
 - [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in [Settings](https://github.com/%REPOSITORY%/settings/secrets/actions).
+- [ ] Code some cool apps and libraries 🚀.
 
 This is your new Kotlin Android Project! Happy hacking!

--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -2,10 +2,11 @@
 
 ![Build](https://github.com/%REPOSITORY%/workflows/Pre%20Merge%20Checks/badge.svg)
 
-## Template ToDo list
+This is your new Kotlin Android Project! Happy hacking!
+
+## Template ToDo list 👣
+
 - [x] Create a new template project.
 - [ ] Choose a [LICENSE](https://github.com/%REPOSITORY%/community/license/new?branch=master).
 - [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in [Settings](https://github.com/%REPOSITORY%/settings/secrets/actions).
 - [ ] Code some cool apps and libraries 🚀.
-
-This is your new Kotlin Android Project! Happy hacking!

--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -1,10 +1,10 @@
 # %NAME%
 
-![Build](https://github.com/%REPOSITORY%/workflows/Build/badge.svg)
+![Build](https://github.com/%REPOSITORY%/workflows/Pre%20Merge%20Checks/badge.svg)
 
 ## Template ToDo list
-- [x] Create a new [Kotlin Android Template][template] project.
-- [ ] Choose a [license](https://github.com/%REPOSITORY%/community/license/new?branch=master).
-- [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in Github Actions.
+- [x] Create a new template project.
+- [ ] Choose a [LICENSE](https://github.com/%REPOSITORY%/community/license/new?branch=master).
+- [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in [Settings](https://github.com/%REPOSITORY%/settings/secrets/actions).
 
 This is your new Kotlin Android Project! Happy hacking!

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   template-cleanup:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
       # Cleanup project
       - name: Cleanup
-        run: ./gradlew publishToMavenLocal
+        run: ./gradlew templateCleanup
       # Commit modified files
       - name: Commit files
         run: |

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,4 +1,4 @@
-# GitHub Actions Workflow responsible for cleaning up the IntelliJ Platform Plugin Template repository from
+# GitHub Actions Workflow responsible for cleaning up the template repository from
 # the template-specific files and configurations. This workflow is supposed to be triggered automatically
 # when a new template-based repository has been created.
 

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -30,7 +30,7 @@ jobs:
           git commit -m "Template cleanup"
       # Push changes
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.6.0
         with:
           branch: master
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -6,7 +6,6 @@ name: Template Cleanup
 on:
   push:
     branches:
-      - main
       - master
 
 jobs:
@@ -33,5 +32,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          branch: main
+          branch: master
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,36 @@
+# GitHub Actions Workflow responsible for cleaning up the IntelliJ Platform Plugin Template repository from
+# the template-specific files and configurations. This workflow is supposed to be triggered automatically
+# when a new template-based repository has been created.
+
+name: Template Cleanup
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  template-cleanup:
+    name: Template Cleanup
+    runs-on: ubuntu-latest
+    if: github.event.repository.name != 'kotlin-android-template'
+    steps:
+
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+      # Cleanup project
+      - name: Cleanup
+        run: ./gradlew publishToMavenLocal
+      # Commit modified files
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Template cleanup"
+      # Push changes
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    # remove this check when your secrets are setup and you're ready to publish
     if: ${{ github.repository == 'cortinico/kotlin-android-template'}}
     runs-on: [ubuntu-latest]
     env:

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    # remove this check when your secrets are setup and you're ready to publish
     if: ${{ github.repository == 'cortinico/kotlin-android-template'}}
     runs-on: [ubuntu-latest]
     env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version BuildPluginsVersion.DETEKT
     id("org.jlleitschuh.gradle.ktlint") version BuildPluginsVersion.KTLINT
     id("com.github.ben-manes.versions") version BuildPluginsVersion.VERSIONS_PLUGIN
+    cleanup
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/cleanup.gradle.kts
+++ b/buildSrc/src/main/kotlin/cleanup.gradle.kts
@@ -29,20 +29,7 @@ tasks.register("templateCleanup") {
         "com.ncorti.kotlin.template",
         "com.github.$owner.$name"
     )
-    /**
-     * This fails with: 'refusing to allow a GitHub App to create or update workflow
-     * `.github/workflows/publish-release.yaml` without `workflows` permission'
-     */
-    /*
-    file(".github/workflows/publish-release.yaml").replace(
-        "cortinico/kotlin-android-template",
-        "$owner/$name"
-    )
-    file(".github/workflows/publish-snapshot.yaml").replace(
-        "cortinico/kotlin-android-template",
-        "$owner/$name"
-    )
-     */
+
     file("buildSrc/src/main/kotlin/publish.gradle.kts").apply {
         replace("cortinico/kotlin-android-template", "$owner/$name")
         replace("cortinico/kotlin-android-template", "$owner/$name")

--- a/buildSrc/src/main/kotlin/cleanup.gradle.kts
+++ b/buildSrc/src/main/kotlin/cleanup.gradle.kts
@@ -1,3 +1,14 @@
+/**
+ * A plugin to cleanup the template after it has been forked. It register a single `templateCleanup`
+ * task that is designed to run from CI. It:
+ * - renames the root project
+ * - replaces the maven coordinates with coordinates based on the Github repository where the
+ * template is forked
+ * - changes the package name
+ * - changes the Android application ID
+ * - cleanups after itself by removing the Github action and this plugin
+ */
+
 check(rootProject.name == name) {
     "The cleanup plugin should be applied to the root project and not $name"
 }

--- a/buildSrc/src/main/kotlin/cleanup.gradle.kts
+++ b/buildSrc/src/main/kotlin/cleanup.gradle.kts
@@ -1,0 +1,99 @@
+check(rootProject.name == name) {
+    "The cleanup plugin should be applied to the root project and not $name"
+}
+
+tasks.register("templateCleanup") {
+    val repository = System.getenv("GITHUB_REPOSITORY")
+        ?: error("No GITHUB_REPOSITORY environment variable. Are you running from Github Actions?")
+
+    val (owner, name) = repository.split("/").let {
+        it[0].sanitized() to it[1].sanitized()
+    }
+
+    file("settings.gradle.kts").replace(
+        "rootProject.name = (\"kotlin-android-template\")",
+        "rootProject.name = (\"$name\")"
+    )
+    file("buildSrc/src/main/java/Coordinates.kt").replace(
+        "com.ncorti.kotlin.template",
+        "com.github.$owner.$name"
+    )
+    file(".github/workflows/publish-release.yaml").replace(
+        "cortinico/kotlin-android-template",
+        "$owner/$name"
+    )
+    file(".github/workflows/publish-snapshot.yaml").replace(
+        "cortinico/kotlin-android-template",
+        "$owner/$name"
+    )
+    file("buildSrc/src/main/kotlin/publish.gradle.kts").apply {
+        replace("cortinico/kotlin-android-template", "$owner/$name")
+        replace("cortinico/kotlin-android-template", "$owner/$name")
+        replace("cortinico", owner)
+        replace("Nicola Corti", owner)
+        // Keep the link to the original script
+        replace(
+            "* https://github.com/$owner/$name/blob/master/buildSrc/src/main/kotlin/publish.gradle.kts",
+        "* https://github.com/cortinico/kotlin-android-template/blob/master/buildSrc/src/main/kotlin/publish.gradle.kts"
+        )
+    }
+
+    copyTemplateFiles(repository, name)
+    changePackageName(owner, name)
+
+    // cleanup the cleanup :)
+    file(".github/template-cleanup").deleteRecursively()
+    file(".github/workflows/cleanup.yaml").delete()
+    file("build.gradle.kts").replace(
+        "    cleanup\n",
+        ""
+    )
+    file("buildSrc/src/main/kotlin/cleanup.gradle.kts").delete()
+}
+
+fun String.sanitized() = replace(Regex("[^A-Za-z0-9]"), "").toLowerCase()
+
+fun File.replace(regex: Regex, replacement: String) {
+    writeText(readText().replace(regex, replacement))
+}
+
+fun File.replace(oldValue: String, newValue: String) {
+    writeText(readText().replace(oldValue, newValue))
+}
+
+fun copyTemplateFiles(repository: String, name: String) {
+    file(".github/template-cleanup")
+        .listFiles()!!
+        .filter { it.isFile }
+        .forEach {
+            it.copyTo(target = file(it.name), overwrite = true)
+            file(it.name).apply {
+                replace("%NAME%", name)
+                replace("%REPOSITORY%", repository)
+            }
+        }
+}
+
+fun srcDirectories() = projectDir.listFiles()!!
+    .filter { it.isDirectory && !(it.name == "buildSrc") }
+    .flatMap { it.listFiles()!!.filter { it.isDirectory && it.name == "src" } }
+
+fun changePackageName(owner: String, name: String) {
+    srcDirectories().forEach {
+        it.walk().filter {
+            it.isFile && (it.extension == "kt" || it.extension == "kts"  || it.extension == "xml")
+        }.forEach {
+            it.replace("com.ncorti.kotlin.template", "com.github.$owner.$name")
+        }
+    }
+    srcDirectories().forEach {
+        it.listFiles()!!.filter { it.isDirectory } // down to src/main
+            .flatMap { it.listFiles()!!.filter { it.isDirectory } } // down to src/main/java
+            .forEach {
+                val newDir = File(it, "com/github/$owner/$name")
+                newDir.parentFile.mkdirs()
+                File(it, "com/ncorti/kotlin/template").renameTo(newDir)
+                File(it, "com/ncorti").deleteRecursively()
+            }
+    }
+}

--- a/buildSrc/src/main/kotlin/cleanup.gradle.kts
+++ b/buildSrc/src/main/kotlin/cleanup.gradle.kts
@@ -42,7 +42,7 @@ tasks.register("templateCleanup") {
         )
     }
 
-    copyTemplateFiles(repository, name)
+    patchReadme(repository, name)
     changePackageName(owner, name)
 
     // cleanup the cleanup :)
@@ -65,17 +65,21 @@ fun File.replace(oldValue: String, newValue: String) {
     writeText(readText().replace(oldValue, newValue))
 }
 
-fun copyTemplateFiles(repository: String, name: String) {
-    file(".github/template-cleanup")
-        .listFiles()!!
-        .filter { it.isFile }
-        .forEach {
-            it.copyTo(target = file(it.name), overwrite = true)
-            file(it.name).apply {
-                replace("%NAME%", name)
-                replace("%REPOSITORY%", repository)
-            }
+fun patchReadme(repository: String, name: String) {
+    val newIntro = file(".github/template-cleanup/README.md")
+            .readText()
+            .replace("%NAME%", name)
+            .replace("%REPOSITORY%", repository)
+
+    var featuresFound = false
+    val existingReadme = file("README.md").readLines().mapNotNull {
+        if (it.startsWith("## Features")) {
+            featuresFound = true
         }
+        if (!featuresFound) null else it
+    }.joinToString("\n")
+
+    file("README.md").writeText(newIntro + "\n" + existingReadme)
 }
 
 fun srcDirectories() = projectDir.listFiles()!!

--- a/buildSrc/src/main/kotlin/cleanup.gradle.kts
+++ b/buildSrc/src/main/kotlin/cleanup.gradle.kts
@@ -18,6 +18,11 @@ tasks.register("templateCleanup") {
         "com.ncorti.kotlin.template",
         "com.github.$owner.$name"
     )
+    /**
+     * This fails with: 'refusing to allow a GitHub App to create or update workflow
+     * `.github/workflows/publish-release.yaml` without `workflows` permission'
+     */
+    /*
     file(".github/workflows/publish-release.yaml").replace(
         "cortinico/kotlin-android-template",
         "$owner/$name"
@@ -26,6 +31,7 @@ tasks.register("templateCleanup") {
         "cortinico/kotlin-android-template",
         "$owner/$name"
     )
+     */
     file("buildSrc/src/main/kotlin/publish.gradle.kts").apply {
         replace("cortinico/kotlin-android-template", "$owner/$name")
         replace("cortinico/kotlin-android-template", "$owner/$name")

--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -105,7 +105,6 @@ afterEvaluate {
                         developer {
                             id.set("cortinico")
                             name.set("Nicola Corti")
-                            email.set("corti.nico@gmail.com")
                         }
                     }
                     scm {


### PR DESCRIPTION
## 🚀 Description
Inspired by the [IntelliJ plugin template](https://github.com/JetBrains/intellij-platform-plugin-template), this PRs adds a new `Template Cleanup` workflow that:
* updates groupId and POM properties
* changes the package name to `com.github.owner.name`
* removes the LICENSE
* updates the README
* cleans up the cleanup scripts 🙃 

The result can be seen in this test repo: https://github.com/logingithubtest/test5

The resulting README feels a bit empty at the moment, feel free to add more context.

Closes #18 