### PR TITLE
Use detekt-formatting plugin instead of ktlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once created don't forget to update the:
 - CI Setup with GitHub Actions.
 - Publish to **Maven Central** with Github Actions.
 - Dependency versions managed via `buildSrc`.
-- Kotlin Static Analysis via `detekt`.
+- Kotlin Static Analysis via `detekt` and `ktlint`.
 - Issues Template (bug report + feature request).
 - Pull Request Template.
 
@@ -36,7 +36,7 @@ Dependencies are centralized inside the [Dependencies.kt](buildSrc/src/main/java
 
 ## Static Analysis 🔍
 
-This template is using [**detekt**](https://github.com/detekt/detekt) to analyze the source code, with the configuration that is stored in the [detekt.yml](config/detekt/detekt.yml) file (the file has been generated with the `detektGenerateConfig` task). It also uses the detekt-formatting plugin include the ktlint rules (see https://detekt.github.io/detekt/formatting.html).
+This template is using [**detekt**](https://github.com/detekt/detekt) to analyze the source code, with the configuration that is stored in the [detekt.yml](config/detekt/detekt.yml) file (the file has been generated with the `detektGenerateConfig` task). It also uses the **detekt-formatting** plugin which includes the ktlint rules (see https://detekt.dev/docs/rules/formatting/).
 
 ## CI ⚙️
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once created don't forget to update the:
 - CI Setup with GitHub Actions.
 - Publish to **Maven Central** with Github Actions.
 - Dependency versions managed via `buildSrc`.
-- Kotlin Static Analysis via `ktlint` and `detekt`.
+- Kotlin Static Analysis via `detekt`.
 - Issues Template (bug report + feature request).
 - Pull Request Template.
 
@@ -36,9 +36,7 @@ Dependencies are centralized inside the [Dependencies.kt](buildSrc/src/main/java
 
 ## Static Analysis 🔍
 
-This template is using [**ktlint**](https://github.com/pinterest/ktlint) with the [ktlint-gradle](https://github.com/jlleitschuh/ktlint-gradle) plugin to format your code. To reformat all the source code as well as the buildscript you can run the `ktlintFormat` gradle task.
-
-This template is also using [**detekt**](https://github.com/detekt/detekt) to analyze the source code, with the configuration that is stored in the [detekt.yml](config/detekt/detekt.yml) file (the file has been generated with the `detektGenerateConfig` task).
+This template is using [**detekt**](https://github.com/detekt/detekt) to analyze the source code, with the configuration that is stored in the [detekt.yml](config/detekt/detekt.yml) file (the file has been generated with the `detektGenerateConfig` task). It also uses the detekt-formatting plugin include the ktlint rules (see https://detekt.github.io/detekt/formatting.html).
 
 ## CI ⚙️
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,10 @@ plugins {
 allprojects {
     group = PUBLISHING_GROUP
 }
+
 val ktlintVersion = libs.versions.ktlint.asProvider().get()
+val detektFormatting = libs.detekt.formatting
+
 subprojects {
     apply {
         plugin("io.gitlab.arturbosch.detekt")
@@ -24,7 +27,7 @@ subprojects {
     }
 
     dependencies {
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${BuildPluginsVersion.DETEKT}")
+        detektPlugins(detektFormatting)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     id("com.android.library") apply false
     kotlin("android") apply false
     alias(libs.plugins.detekt)
-    alias(libs.plugins.ktlint)
     alias(libs.plugins.versions)
     cleanup
     base
@@ -18,25 +17,14 @@ val ktlintVersion = libs.versions.ktlint.asProvider().get()
 subprojects {
     apply {
         plugin("io.gitlab.arturbosch.detekt")
-        plugin("org.jlleitschuh.gradle.ktlint")
-    }
-
-    ktlint {
-        debug.set(false)
-        version.set(ktlintVersion)
-        verbose.set(true)
-        android.set(false)
-        outputToConsole.set(true)
-        ignoreFailures.set(false)
-        enableExperimentalRules.set(true)
-        filter {
-            exclude("**/generated/**")
-            include("**/kotlin/**")
-        }
     }
 
     detekt {
         config = rootProject.files("config/detekt/detekt.yml")
+    }
+
+    dependencies {
+        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${BuildPluginsVersion.DETEKT}")
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ androidx_test_rules = { module = "androidx.test:rules", version.ref = "androidx.
 androidx_test_runner = { module = "androidx.test:runner", version.ref = "androidx.test" }
 androidx_test_ext_junit = { module = "androidx.test.ext:junit", version.ref = "androidx.test.ext" }
 androidx_test_ext_junit_ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx.test.ext" }
+detekt_formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 espresso_core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso.core" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Replace ktlint by the detekt-formatting plugin. This is basically the same but you only have to use one single code static analyzer (see https://detekt.github.io/detekt/formatting.html).

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It's often hard to use two different static code analyzer for almost the same thing. You have to implement both analyzer to the CI, run both analyzer during each PR etc. With the `detekt-formatting` plugin the ktlint analyze process will be included in the detekt analyze process which solves this issue. 

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Simply do some code/styling mistakes 😄 

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.