### PR TITLE
Update signing logging

### DIFF
--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -125,7 +125,7 @@ afterEvaluate {
         if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
             logger.info("Signing Disable as the PGP key was not found")
         } else {
-            logger.warn("Usign $signingKey - $signingPwd")
+            logger.info("GPG Key found - Signing enabled")
             signing {
                 useInMemoryPgpKeys(signingKey, signingPwd)
                 sign(publishing.publications["release"])


### PR DESCRIPTION
## 🚀 Description
I'm updating the signing setup to don't print the used GPG key.
If you happened to use Github Actions (as this template recommends) your secrets won't be compromised (they're anyway redacted). 
But if you happend to use another CI that is not redacting secrets, you might expose them to public.