### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -7,6 +7,6 @@ This is your new Kotlin Android Project! Happy hacking!
 ## Template ToDo list 👣
 
 - [x] Create a new template project.
-- [ ] Choose a [LICENSE](https://github.com/%REPOSITORY%/community/license/new?branch=master).
+- [ ] Choose a [LICENSE](https://github.com/%REPOSITORY%/community/license/new?branch=main).
 - [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in [Settings](https://github.com/%REPOSITORY%/settings/secrets/actions).
 - [ ] Code some cool apps and libraries 🚀.

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -6,7 +6,7 @@ name: Template Cleanup
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   template-cleanup:
@@ -37,5 +37,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0
         with:
-          branch: master
+          branch: main
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -2,7 +2,7 @@ name: Validate Gradle Wrapper
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -3,7 +3,7 @@ name: Pre Merge Checks
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -2,7 +2,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 🚀 Description
After renaming the default branch to `main`, there are still some leftovers to cleanup here. Resolving them.