### PR TITLE
Resolve several Gradle build warnings

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,4 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,14 +1,4 @@
 pluginManagement {
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "com.android.library") {
-                useModule("com.android.tools.build:gradle:${requested.version}")
-            }
-            if (requested.id.id == "com.android.application") {
-                useModule("com.android.tools.build:gradle:${requested.version}")
-            }
-        }
-    }
     repositories {
         gradlePluginPortal()
         google()
@@ -25,7 +15,6 @@ dependencyResolutionManagement {
 
 rootProject.name = ("kotlin-android-template")
 
-enableFeaturePreview("VERSION_CATALOGS")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(


### PR DESCRIPTION
## 🚀 Description
- enableFeaturePreview("VERSION_CATALOGS") has been promoted to stable, will be removed inside Gradle 8.0
- Resolution Strategy for plugin markers of AGP is not needed anymore