### PR TITLE
Switch to use the Gradle build Action

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -23,6 +23,9 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
+      # Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       # Cleanup project
       - name: Cleanup
         run: ./gradlew templateCleanup

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,20 +18,15 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Cache Gradle Files
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
-          
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Run Gradle
         run: ./gradlew build check publishToMavenLocal --continue
-      - name: Stop Gradle
-        run: ./gradlew --stop

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -24,6 +24,9 @@ jobs:
           distribution: 'adopt'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Publish to Maven Local
         run: ./gradlew publishToMavenLocal
         env:

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -24,6 +24,9 @@ jobs:
           distribution: 'adopt'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Publish to Maven Local
         run: ./gradlew publishToMavenLocal
         env:


### PR DESCRIPTION
## 🚀 Description
There is no need to manually specify which folders to cache for Gradle. Let's use 
https://github.com/gradle/gradle-build-action instead.