### PR TITLE
Fix broken path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once created don't forget to update the:
 
 This template is using [**Gradle Kotlin DSL**](https://docs.gradle.org/current/userguide/kotlin_dsl.html) as well as the [Plugin DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) to setup the build.
 
-Dependencies are centralized inside the [libs.versions.toml](gradle/libs.versions.toml) file in the `gradle` folder. This provides convenient auto-completion when writing your gradle files.
+Dependencies are centralized inside the Gradle Version Catalog in the [libs.versions.toml](gradle/libs.versions.toml) file in the `gradle` folder.
 
 ## Static Analysis 🔍
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once created don't forget to update the:
 
 This template is using [**Gradle Kotlin DSL**](https://docs.gradle.org/current/userguide/kotlin_dsl.html) as well as the [Plugin DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) to setup the build.
 
-Dependencies are centralized inside the [Dependencies.kt](buildSrc/src/main/java/Dependencies.kt) file in the `buildSrc` folder. This provides convenient auto-completion when writing your gradle files.
+Dependencies are centralized inside the [libs.versions.toml](gradle/libs.versions.toml) file in the `gradle` folder. This provides convenient auto-completion when writing your gradle files.
 
 ## Static Analysis 🔍
 


### PR DESCRIPTION

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
The Dependencies.kt mentioned in the [README](https://github.com/cortinico/kotlin-android-template/README.md) does not exist:
`buildSrc/src/main/java/Dependencies.kt` now is `gradle/libs.versions.toml`
This PR updates the reference.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/cortinico/kotlin-android-template/issues/80


## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.