### PR TITLE
Suppress warning for buildSrc not having a project name

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -5,3 +5,4 @@ dependencyResolutionManagement {
         }
     }
 }
+rootProject.name = ("buildSrc")


### PR DESCRIPTION
## 🚀 Description
This suppressess the warning on console for:

> Project accessors enabled, but root project name not explicitly set for 'buildSrc'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.

## 🧪 How Has This Been Tested?
Tested locally with `gw build`.