### PR TITLE
Do not fail lint on GradleDependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ android {
     lint {
         warningsAsErrors = true
         abortOnError = true
+        disable.add("GradleDependency")
     }
 
     // Use this block to configure different flavors

--- a/library-android/build.gradle.kts
+++ b/library-android/build.gradle.kts
@@ -47,6 +47,7 @@ android {
     lint {
         warningsAsErrors = true
         abortOnError = true
+        disable.add("GradleDependency")
     }
 }
 

--- a/library-compose/build.gradle.kts
+++ b/library-compose/build.gradle.kts
@@ -39,6 +39,7 @@ android {
     lint {
         warningsAsErrors = true
         abortOnError = true
+        disable.add("GradleDependency")
     }
 }
 


### PR DESCRIPTION
## 🚀 Description
CI often fails because of `GradleDependency`.
As there is Renovate in place, it makes sense to actually disable the `GradleDependency` lint check.