### PR TITLE
Introduce composeBom instead of version reference

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ androidx_test = "1.5.0"
 androidx_test_ext = "1.1.5"
 appcompat = "1.6.1"
 compile_sdk_version = "34"
-compose = "1.5.4"
+compose-bom = "2023.10.01"
 compose_compilerextension = "1.5.5"
 constraint_layout = "2.1.4"
 core_ktx = "1.12.0"
@@ -27,12 +27,13 @@ androidx_test_rules = { module = "androidx.test:rules", version.ref = "androidx.
 androidx_test_runner = { module = "androidx.test:runner", version.ref = "androidx.test" }
 androidx_test_ext_junit = { module = "androidx.test.ext:junit", version.ref = "androidx.test.ext" }
 androidx_test_ext_junit_ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx.test.ext" }
-compose_material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose_foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose_ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-compose_ui_tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose_ui_test_junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
-compose_ui_test_manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+compose_material = { module = "androidx.compose.material:material" }
+compose_foundation = { module = "androidx.compose.foundation:foundation" }
+compose_ui = { module = "androidx.compose.ui:ui" }
+compose_ui_tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose_ui_test_junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+compose_ui_test_manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 detekt_formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 espresso_core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso.core" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/library-compose/build.gradle.kts
+++ b/library-compose/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.androidx.activity.compose)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling)


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR aims to resolve this [issue](https://github.com/cortinico/kotlin-android-template/issues/186), to use composeBom rather than version reference

## 📄 Motivation and Context
It resolves [this issue](https://github.com/cortinico/kotlin-android-template/issues/186)

## 🧪 How Has This Been Tested?
I run the project on an emulator Pixel 7 Pro API 34
Project runs without problems.
The only problem that is also seen on master is that min_sdk_version should be bumped because ui compose test fails. It can be fixed in a [separate PR](https://github.com/cortinico/kotlin-android-template/pull/206).
![Screenshot_2](https://github.com/cortinico/kotlin-android-template/assets/31949421/57ef93be-b3c9-4194-8980-c79a27eaea89)

![Screenshot_1](https://github.com/cortinico/kotlin-android-template/assets/31949421/fbd9d9e7-2075-4e70-8009-fdb8e6a225d0)

## 📷 Screenshots (if appropriate)
Already provided

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.