### PR TITLE
Bump minSdk

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ detekt = "1.23.4"
 espresso_core = "3.5.1"
 junit = "4.13.2"
 kotlin = "1.9.20"
-min_sdk_version = "21"
+min_sdk_version = "24"
 target_sdk_version = "34"
 benmanesversion = "0.50.0"
 


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
While [testing composeBom](https://github.com/cortinico/kotlin-android-template/pull/205), it was noticed that compose ui test fails even on master. The problem is that minSdk is low

## 📄 Motivation and Context
It fixes the failed compose ui test

## 🧪 How Has This Been Tested?
The project builds and runs successfully.
compose ui test runs successfully
![Screenshot_3](https://github.com/cortinico/kotlin-android-template/assets/31949421/351220dd-1538-43ea-a68d-fe7c1e7e4ce3)


## 📷 Screenshots (if appropriate)
Provided

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.