### PR TITLE
Add 'Template Cleanup fails in first Workflow' in TROUBLESHOOTING.md

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -31,7 +31,9 @@ Execution failed for task ':library-compose:detekt'.
 If the error occurs in the **Push changes** step of the workflow and you encounter errors such as:
 
 ```
-fatal: unable to access 'https://github.com/<username>/<repo>.git/': The requested URL returned error: 403 Error: Invalid exit code: 128
+fatal: unable to access 'https://github.com/<username>/<repo>.git/':
+The requested URL returned error: 403 
+Error: Invalid exit code: 128
 ```
 
 then the issue is likely due to the workflow permissions of your repository. To resolve this, navigate to your repository settings, go to **Actions -> General**, and set the Workflow Permissions to **Read and Write**.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -25,3 +25,15 @@ FAILURE: Build failed with an exception.
 Execution failed for task ':library-compose:detekt'.
 > Invalid value (20) passed to --jvm-target, must be one of [1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
 ```
+
+# Template Cleanup fails in first Workflow
+
+If the error occurs in the **Push changes** step of the workflow and you encounter errors such as:
+
+```
+fatal: unable to access 'https://github.com/<username>/<repo>.git/': The requested URL returned error: 403 Error: Invalid exit code: 128
+```
+
+then the issue is likely due to the workflow permissions of your repository. To resolve this, navigate to your repository settings, go to **Actions -> General**, and set the Workflow Permissions to **Read and Write**.
+
+Once the workflow completes successfully, you can and probably should revert the permissions back to the default settings.


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Using this template might lead to a GitHub Action failure, which is discouraging and adds extra work before real development starts.

## 📄 Motivation and Context
When I set up a new repository with this template, I ran into this issue. I couldn’t find an answer within the repository, so this PR aims to help developers troubleshoot it more quickly.

## 🧪 How Has This Been Tested?

This update is a small addition to TROUBLESHOOTING.md, outlining the steps I took to resolve the problem.

## 📷 Screenshots (if appropriate)

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.